### PR TITLE
broker: subscribers: use a slice instead of a map

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,44 @@
+package ps_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/peterbourgon/ps"
+)
+
+func BenchmarkBrokerMethods(b *testing.B) {
+	subscribers := []int{
+		0,
+		1,
+		100,
+		10000,
+	}
+
+	tcs := []struct {
+		name string
+		fn   func(*ps.Broker[int])
+	}{
+		{"Publish", func(b *ps.Broker[int]) { b.Publish(123) }},
+		{"Sub-Unsub", func(b *ps.Broker[int]) { c := make(chan int); b.SubscribeAll(c); b.Unsubscribe(c) }},
+		{"ActiveSubscribers", func(b *ps.Broker[int]) { b.ActiveSubscribers() }},
+	}
+
+	for _, tc := range tcs {
+		b.Run(tc.name, func(b *testing.B) {
+			for _, nsubs := range subscribers {
+				b.Run(strconv.Itoa(nsubs), func(b *testing.B) {
+					broker := ps.NewBroker[int]()
+					for i := 0; i < nsubs; i++ {
+						broker.Subscribe(make(chan int), func(int) bool { return true })
+					}
+					b.ResetTimer()
+					b.ReportAllocs()
+					for i := 0; i < b.N; i++ {
+						tc.fn(broker)
+					}
+				})
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/peterbourgon/ps
 
 go 1.20
-
-require github.com/bernerdschaefer/eventsource v0.0.0-20130606115634-220e99a79763

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/bernerdschaefer/eventsource v0.0.0-20130606115634-220e99a79763 h1:Xhc57KuvOszD8WMiNzIeTfmpfUJ9lodF/j/cTN0v0Is=
-github.com/bernerdschaefer/eventsource v0.0.0-20130606115634-220e99a79763/go.mod h1:Son4chyIHRln8G19kywUdR55p9OsyCC0zi9CY9Me92k=


### PR DESCRIPTION
In summary, using a slice makes Publish faster by up to 1 order of magnitude, but also makes Subscribe-Unsubscribe slower by order(s) of magnitude proportional to the number of active subscribers. I think this is a net win, because Publish performance matters a lot more than Subscribe-Unsubscribe performance. Thanks to @oliverpool for the tip in #1.

```
name                                      old time/op    new time/op    delta
BrokerMethods/Publish/0-11                  7.17ns ± 0%    6.00ns ± 0%     -16.33%  (p=0.016 n=5+4)
BrokerMethods/Publish/1-11                  34.3ns ± 0%     7.7ns ± 4%     -77.51%  (p=0.016 n=4+5)
BrokerMethods/Publish/100-11                1.05µs ± 4%    0.33µs ± 2%     -68.74%  (p=0.008 n=5+5)
BrokerMethods/Publish/10000-11               108µs ± 1%      32µs ± 1%     -70.12%  (p=0.008 n=5+5)
BrokerMethods/Sub-Unsub/0-11                78.6ns ± 1%    62.9ns ± 1%     -19.97%  (p=0.008 n=5+5)
BrokerMethods/Sub-Unsub/1-11                78.1ns ± 1%    65.0ns ± 2%     -16.80%  (p=0.008 n=5+5)
BrokerMethods/Sub-Unsub/100-11              95.8ns ± 4%   206.7ns ± 0%    +115.86%  (p=0.008 n=5+5)
BrokerMethods/Sub-Unsub/10000-11             109ns ± 2%   20155ns ± 1%  +18373.88%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/0-11        35.1ns ± 2%     6.4ns ± 2%     -81.65%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/1-11        96.3ns ± 4%    16.9ns ± 1%     -82.51%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/100-11      1.45µs ± 2%    0.26µs ± 1%     -81.71%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/10000-11     183µs ± 0%      27µs ± 4%     -85.29%  (p=0.008 n=5+5)

name                                      old alloc/op   new alloc/op   delta
BrokerMethods/Publish/0-11                   0.00B          0.00B             ~     (all equal)
BrokerMethods/Publish/1-11                   0.00B          0.00B             ~     (all equal)
BrokerMethods/Publish/100-11                 0.00B          0.00B             ~     (all equal)
BrokerMethods/Publish/10000-11               0.00B          0.00B             ~     (all equal)
BrokerMethods/Sub-Unsub/0-11                  144B ± 0%      160B ± 0%     +11.11%  (p=0.008 n=5+5)
BrokerMethods/Sub-Unsub/1-11                  144B ± 0%      160B ± 0%     +11.11%  (p=0.008 n=5+5)
BrokerMethods/Sub-Unsub/100-11                144B ± 0%      160B ± 0%     +11.11%  (p=0.008 n=5+5)
BrokerMethods/Sub-Unsub/10000-11              144B ± 0%      160B ± 0%     +11.11%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/0-11         24.0B ± 0%      0.0B         -100.00%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/1-11         80.0B ± 0%     24.0B ± 0%     -70.00%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/100-11      6.25kB ± 0%    2.69kB ± 0%     -56.98%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/10000-11     574kB ± 0%     246kB ± 0%     -57.15%  (p=0.000 n=5+4)

name                                      old allocs/op  new allocs/op  delta
BrokerMethods/Publish/0-11                    0.00           0.00             ~     (all equal)
BrokerMethods/Publish/1-11                    0.00           0.00             ~     (all equal)
BrokerMethods/Publish/100-11                  0.00           0.00             ~     (all equal)
BrokerMethods/Publish/10000-11                0.00           0.00             ~     (all equal)
BrokerMethods/Sub-Unsub/0-11                  3.00 ± 0%      3.00 ± 0%        ~     (all equal)
BrokerMethods/Sub-Unsub/1-11                  3.00 ± 0%      3.00 ± 0%        ~     (all equal)
BrokerMethods/Sub-Unsub/100-11                3.00 ± 0%      3.00 ± 0%        ~     (all equal)
BrokerMethods/Sub-Unsub/10000-11              3.00 ± 0%      3.00 ± 0%        ~     (all equal)
BrokerMethods/ActiveSubscribers/0-11          1.00 ± 0%      0.00         -100.00%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/1-11          3.00 ± 0%      1.00 ± 0%     -66.67%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/100-11        5.00 ± 0%      1.00 ± 0%     -80.00%  (p=0.008 n=5+5)
BrokerMethods/ActiveSubscribers/10000-11      5.00 ± 0%      1.00 ± 0%     -80.00%  (p=0.008 n=5+5)
```