### PR TITLE
pshttp: HTTP interface to a ps.Broker

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,14 +21,15 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.x
+          check-latest: true
 
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }} # default is a pseudo 'merge' commit
 
       - name: Prepare cache
         id: cache
@@ -55,7 +56,6 @@ jobs:
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
           go install mvdan.cc/gofumpt@latest
-          go install github.com/mgechev/revive@latest
 
       - name: Run gofmt
         if: matrix.platform != 'windows-latest' # :<
@@ -69,9 +69,6 @@ jobs:
 
       - name: Run gofumpt
         run: gofumpt -d -e -l .
-
-      - name: Run revive
-        run: revive --set_exit_status ./...
 
       - name: Run lint-parallel-tests
         run: hack/lint-parallel-tests

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/peterbourgon/ps
 
-go 1.22
+go 1.24
 
 require github.com/peterbourgon/eventsource v0.0.0-20240918134904-0c90791d8b55

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/peterbourgon/ps
 
-go 1.20
+go 1.22
+
+require github.com/peterbourgon/eventsource v0.0.0-20240721131530-09aa61eb57d6

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/peterbourgon/ps
 
 go 1.22
 
-require github.com/peterbourgon/eventsource v0.0.0-20240721131530-09aa61eb57d6
+require github.com/peterbourgon/eventsource v0.0.0-20240918134904-0c90791d8b55

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/peterbourgon/eventsource v0.0.0-20240721131530-09aa61eb57d6 h1:yyYgnlPR1NyxCjIHvfMcYlPsonqzT/Wlz5Ok40um37Q=
-github.com/peterbourgon/eventsource v0.0.0-20240721131530-09aa61eb57d6/go.mod h1:G0wYxkDKzkcjHvQZMymDnlb/vaSuY8LV3+QAU1ICHjk=
+github.com/peterbourgon/eventsource v0.0.0-20240918134904-0c90791d8b55 h1:kJsFyRsR8+Wo0xNzhQywJfOGQQoaQPmsc+rw+9BdzlI=
+github.com/peterbourgon/eventsource v0.0.0-20240918134904-0c90791d8b55/go.mod h1:G0wYxkDKzkcjHvQZMymDnlb/vaSuY8LV3+QAU1ICHjk=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/peterbourgon/eventsource v0.0.0-20240721131530-09aa61eb57d6 h1:yyYgnlPR1NyxCjIHvfMcYlPsonqzT/Wlz5Ok40um37Q=
+github.com/peterbourgon/eventsource v0.0.0-20240721131530-09aa61eb57d6/go.mod h1:G0wYxkDKzkcjHvQZMymDnlb/vaSuY8LV3+QAU1ICHjk=

--- a/ps.go
+++ b/ps.go
@@ -16,13 +16,13 @@ var (
 // Stats represents the outcome of one or more published values.
 type Stats struct {
 	// Skips are values that were not sent due to filtering rules.
-	Skips uint64
+	Skips uint64 `json:"skips"`
 
 	// Sends are values that were sent successfully.
-	Sends uint64
+	Sends uint64 `json:"sends"`
 
 	// Drops are values that failed to send because the subscriber blocked.
-	Drops uint64
+	Drops uint64 `json:"drops"`
 }
 
 // Total number of values represented by the stats.
@@ -32,5 +32,5 @@ func (s Stats) Total() uint64 {
 
 // String representation of the stats.
 func (s Stats) String() string {
-	return fmt.Sprintf("Skips=%d Sends=%d Drops=%d Total=%d", s.Skips, s.Sends, s.Drops, s.Total())
+	return fmt.Sprintf("skips=%d sends=%d drops=%d", s.Skips, s.Sends, s.Drops)
 }

--- a/pshttp/client.go
+++ b/pshttp/client.go
@@ -24,10 +24,10 @@ type Client[T any] struct {
 	decode DecodeFunc[T]
 }
 
-// NewDefaultClient calls NewClient with [http.DefaultClient] and the default
-// [Encode] and [Decode] functions.
+// NewDefaultClient calls [NewClient] with [http.DefaultClient] and the default
+// [EncodeJSON] and [DecodeJSON] functions.
 func NewDefaultClient[T any](uri string) (*Client[T], error) {
-	return NewClient(http.DefaultClient, uri, Encode[T], Decode[T])
+	return NewClient(http.DefaultClient, uri, EncodeJSON[T], DecodeJSON[T])
 }
 
 // NewClient constructs a new client targeting the given URI.

--- a/pshttp/client.go
+++ b/pshttp/client.go
@@ -1,0 +1,106 @@
+package pshttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/peterbourgon/eventsource"
+	"github.com/peterbourgon/ps"
+)
+
+type Client[T any] struct {
+	client *http.Client
+	uri    string
+	encode EncodeFunc[T]
+	decode DecodeFunc[T]
+}
+
+func NewDefaultClient[T any](uri string) (*Client[T], error) {
+	return NewClient(http.DefaultClient, uri, Encode[T], Decode[T])
+}
+
+func NewClient[T any](client *http.Client, uri string, encode EncodeFunc[T], decode DecodeFunc[T]) (*Client[T], error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URI: %w", err)
+	}
+
+	uri = u.String()
+
+	return &Client[T]{
+		client: client,
+		uri:    uri,
+		encode: encode,
+		decode: decode,
+	}, nil
+}
+
+func (c *Client[T]) Publish(ctx context.Context, v T) (ps.Stats, error) {
+	var buf bytes.Buffer
+	if err := c.encode(v, &buf); err != nil {
+		return ps.Stats{}, fmt.Errorf("encode value: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.uri, bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		return ps.Stats{}, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return ps.Stats{}, fmt.Errorf("execute request: %w", err)
+	}
+	defer func() {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return ps.Stats{}, fmt.Errorf("invalid response (%s)", resp.Status)
+	}
+
+	var stats ps.Stats
+	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+		return ps.Stats{}, fmt.Errorf("decode response stats: %w", err)
+	}
+
+	return stats, nil
+}
+
+func (c *Client[T]) Subscribe(ctx context.Context, ch chan<- T, retry time.Duration) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.uri, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	es := eventsource.New(req, retry)
+	defer es.Close()
+
+	for {
+		ev, err := es.Read()
+		if err != nil {
+			return fmt.Errorf("read event: %w", err)
+		}
+		if ev.Type != EventTypeData {
+			continue // TODO
+		}
+
+		var v T
+		if err := c.decode(bytes.NewReader(ev.Data), &v); err != nil {
+			return fmt.Errorf("decode event: %w", err)
+		}
+
+		select {
+		case ch <- v:
+			// good
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/pshttp/doc.go
+++ b/pshttp/doc.go
@@ -1,0 +1,10 @@
+// Package pshttp provides an HTTP interface to a ps.Broker.
+//
+// [Handler] wraps a [ps.Broker] and implements [http.Handler]. It accepts POST
+// requests for publishing events, and GET requests for subscribing to events.
+// Subscriptions are implemented via SSE, so GET requests must accept:
+// text/event-stream.
+//
+// [Client] wraps a remote URI, which is assumed to be handled by a [Handler].
+// It provides publish and subscribe methods similar to a [ps.Broker].
+package pshttp

--- a/pshttp/doc.go
+++ b/pshttp/doc.go
@@ -1,10 +1,11 @@
 // Package pshttp provides an HTTP interface to a ps.Broker.
 //
-// [Handler] wraps a [ps.Broker] and implements [http.Handler]. It accepts POST
-// requests for publishing events, and GET requests for subscribing to events.
-// Subscriptions are implemented via SSE, so GET requests must accept:
-// text/event-stream.
+// [NewHandler] wraps a [ps.Broker] and returns an [http.Handler]. The handler
+// accepts POST requests for publishing events, and GET requests for subscribing
+// to events. Subscriptions are implemented via server-sent events, or SSE, so
+// GET requests must accept: text/event-stream.
 //
-// [Client] wraps a remote URI, which is assumed to be handled by a [Handler].
-// It provides publish and subscribe methods similar to a [ps.Broker].
+// [Client] wraps a remote URI, which is assumed to be handled by a handler
+// returned by [NewHandler]. It provides publish and subscribe methods similar
+// to a [ps.Broker].
 package pshttp

--- a/pshttp/encode_decode.go
+++ b/pshttp/encode_decode.go
@@ -14,12 +14,12 @@ type EncodeFunc[T any] func(T, io.Writer) error
 // EncodeFunc.
 type DecodeFunc[T any] func(io.Reader, *T) error
 
-// Encode is a default EncodeFunc that encodes the value as JSON.
-func Encode[T any](v T, w io.Writer) error {
+// EncodeJSON is a default EncodeFunc that encodes the value as JSON.
+func EncodeJSON[T any](v T, w io.Writer) error {
 	return json.NewEncoder(w).Encode(v)
 }
 
-// Decode is a default DecodeFunc that decodes the value as JSON.
-func Decode[T any](r io.Reader, v *T) error {
+// DecodeJSON is a default DecodeFunc that decodes the value as JSON.
+func DecodeJSON[T any](r io.Reader, v *T) error {
 	return json.NewDecoder(r).Decode(v)
 }

--- a/pshttp/encode_decode.go
+++ b/pshttp/encode_decode.go
@@ -1,0 +1,25 @@
+package pshttp
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// EncodeFunc encodes a value of type T to the writer. The encoded bytes must be
+// valid UTF-8. Every EncodeFunc should have a corresponding DecodeFunc.
+type EncodeFunc[T any] func(T, io.Writer) error
+
+// DecodeFunc decodes a value of type T from the reader. The decoded bytes are
+// expected to be valid UTF-8. Every DecodeFunc should have a corresponding
+// EncodeFunc.
+type DecodeFunc[T any] func(io.Reader, *T) error
+
+// Encode is a default EncodeFunc that encodes the value as JSON.
+func Encode[T any](v T, w io.Writer) error {
+	return json.NewEncoder(w).Encode(v)
+}
+
+// Decode is a default DecodeFunc that decodes the value as JSON.
+func Decode[T any](r io.Reader, v *T) error {
+	return json.NewDecoder(r).Decode(v)
+}

--- a/pshttp/events.go
+++ b/pshttp/events.go
@@ -1,0 +1,23 @@
+package pshttp
+
+import (
+	"time"
+
+	"github.com/peterbourgon/ps"
+)
+
+const (
+	// EventTypeData is the EventSource type for data events.
+	EventTypeData = "data/v1"
+
+	// EventTypeHeartbeat is the EventSource type for heartbeat events. The
+	// event data is the JSON encoding of a [HeartbeatEvent] value.
+	EventTypeHeartbeat = "heartbeat/v1"
+)
+
+// HeartbeatEvent is sent under the [EventTypeHeartbeat] type.
+type HeartbeatEvent struct {
+	Timestamp time.Time `json:"ts"`
+	Stats     ps.Stats  `json:"stats,omitempty"`
+	Error     string    `json:"error,omitempty"`
+}

--- a/pshttp/handler.go
+++ b/pshttp/handler.go
@@ -76,11 +76,12 @@ func (h *handler[T]) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusInternalServerError, fmt.Errorf("subscribe: %w", err))
 		return
 	}
-	logger.Printf("subscribe")
 	defer func() {
 		stats, err := h.broker.Unsubscribe(c)
 		logger.Printf("unsubscribe: %v (err=%v)", stats, err)
 	}()
+
+	logger.Printf("subscribe: event buffer size %d, heartbeat interval %v", buffer, heartbeat)
 
 	heartbeats := time.NewTicker(heartbeat)
 	defer heartbeats.Stop()

--- a/pshttp/handler.go
+++ b/pshttp/handler.go
@@ -1,0 +1,153 @@
+package pshttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/peterbourgon/eventsource"
+	"github.com/peterbourgon/ps"
+)
+
+type handler[T any] struct {
+	http.Handler
+	broker *ps.Broker[T]
+	encode EncodeFunc[T]
+	decode DecodeFunc[T]
+	logger *log.Logger
+}
+
+func NewDefaultHandler[T any](broker *ps.Broker[T]) http.Handler {
+	return NewHandler(broker, Encode[T], Decode[T], io.Discard)
+}
+
+func NewHandler[T any](broker *ps.Broker[T], encode EncodeFunc[T], decode DecodeFunc[T], logs io.Writer) http.Handler {
+	h := &handler[T]{
+		broker: broker,
+		encode: encode,
+		decode: decode,
+		logger: log.New(logs, "pshttp.Handler: ", log.Lmsgprefix),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /", h.handlePublish)
+	mux.HandleFunc("GET /", h.handleSubscribe)
+	h.Handler = mux
+
+	return h
+}
+
+func (h *handler[T]) handlePublish(w http.ResponseWriter, r *http.Request) {
+	var v T
+	if err := h.decode(r.Body, &v); err != nil {
+		respondJSON(w, http.StatusBadRequest, err)
+		return
+	}
+	stats := h.broker.Publish(v)
+	respondJSON(w, http.StatusOK, stats)
+}
+
+func (h *handler[T]) handleSubscribe(w http.ResponseWriter, r *http.Request) {
+	if !requestExplicitlyAccepts(r, "text/event-stream") {
+		respondJSON(w, http.StatusBadRequest, fmt.Errorf("request must accept: text/event-stream"))
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		respondJSON(w, http.StatusInternalServerError, fmt.Errorf("response writer must support flushing"))
+		return
+	}
+
+	var (
+		ctx       = r.Context()
+		logger    = log.New(h.logger.Writer(), h.logger.Prefix()+fmt.Sprintf("%s: ", r.RemoteAddr), h.logger.Flags())
+		buffer    = parseDefault(r.URL.Query().Get("buffer"), strconv.Atoi, 100)
+		heartbeat = parseDefault(r.URL.Query().Get("heartbeat"), time.ParseDuration, 3*time.Second)
+		c         = make(chan T, buffer)
+	)
+
+	if err := h.broker.SubscribeAll(c); err != nil {
+		respondJSON(w, http.StatusInternalServerError, fmt.Errorf("subscribe: %w", err))
+		return
+	}
+	logger.Printf("subscribe")
+	defer func() {
+		stats, err := h.broker.Unsubscribe(c)
+		logger.Printf("unsubscribe: %v (err=%v)", stats, err)
+	}()
+
+	heartbeats := time.NewTicker(heartbeat)
+	defer heartbeats.Stop()
+
+	eventsource.Handler(func(lastID string, enc *eventsource.Encoder, stop <-chan bool) {
+		err := func() error {
+			var buf bytes.Buffer
+			for {
+				select {
+				case v := <-c:
+					buf.Reset()
+					if err := h.encode(v, &buf); err != nil {
+						return fmt.Errorf("encode value: %w", err)
+					}
+					if err := enc.Encode(eventsource.Event{
+						Type: EventTypeData,
+						Data: buf.Bytes(),
+					}); err != nil {
+						return fmt.Errorf("encode data event: %w", err)
+					}
+					flusher.Flush()
+
+				case ts := <-heartbeats.C:
+					ev := HeartbeatEvent{
+						Timestamp: ts,
+					}
+					if stats, err := h.broker.Stats(c); err == nil {
+						ev.Stats = stats
+					} else {
+						ev.Error = err.Error()
+					}
+					data, err := json.Marshal(ev)
+					if err != nil {
+						return fmt.Errorf("marshal heartbeat event: %w", err)
+					}
+					if err := enc.Encode(eventsource.Event{
+						Type: EventTypeHeartbeat,
+						Data: data,
+					}); err != nil {
+						return fmt.Errorf("encode heartbeat event: %w", err)
+					}
+					flusher.Flush()
+
+				case <-stop:
+					return fmt.Errorf("stop signalled")
+
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		}()
+		switch {
+		case err == nil:
+			logger.Printf("handler exiting")
+		case err != nil:
+			logger.Printf("handler exiting (%v)", err)
+		}
+	}).ServeHTTP(w, r)
+}
+
+const (
+	EventTypeData      = "data/v1"
+	EventTypeHeartbeat = "heartbeat/v1"
+)
+
+type HeartbeatEvent struct {
+	Timestamp time.Time `json:"ts"`
+	Stats     ps.Stats  `json:"stats,omitempty"`
+	Error     string    `json:"error,omitempty"`
+}

--- a/pshttp/pshttp_test.go
+++ b/pshttp/pshttp_test.go
@@ -17,7 +17,7 @@ func TestBasics(t *testing.T) {
 	ctx := context.Background()
 	broker := ps.NewBroker[int64]()
 
-	handler := pshttp.NewHandler(broker, pshttp.Encode, pshttp.Decode, newTestWriter(t))
+	handler := pshttp.NewHandler(broker, pshttp.EncodeJSON, pshttp.DecodeJSON, newTestWriter(t))
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 

--- a/pshttp/pshttp_test.go
+++ b/pshttp/pshttp_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -18,7 +17,7 @@ func TestBasics(t *testing.T) {
 	ctx := context.Background()
 	broker := ps.NewBroker[int64]()
 
-	handler := pshttp.NewHandler(broker, pshttp.Encode, pshttp.Decode, os.Stderr)
+	handler := pshttp.NewHandler(broker, pshttp.Encode, pshttp.Decode, newTestWriter(t))
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
@@ -90,4 +89,19 @@ func TestBasics(t *testing.T) {
 	publish(4)
 	recvAndCheck(v1, 0)
 	recvAndCheck(v2, 0)
+}
+
+type testWriter struct {
+	tb testing.TB
+}
+
+func newTestWriter(tb testing.TB) *testWriter {
+	return &testWriter{
+		tb: tb,
+	}
+}
+
+func (tw *testWriter) Write(p []byte) (int, error) {
+	tw.tb.Logf("%s", string(p))
+	return len(p), nil
 }

--- a/pshttp/pshttp_test.go
+++ b/pshttp/pshttp_test.go
@@ -1,0 +1,93 @@
+package pshttp_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/peterbourgon/ps"
+	"github.com/peterbourgon/ps/pshttp"
+)
+
+func TestBasics(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	broker := ps.NewBroker[int64]()
+
+	handler := pshttp.NewHandler(broker, pshttp.Encode, pshttp.Decode, os.Stderr)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := pshttp.NewDefaultClient[int64](server.URL)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	spawn := func() (valc chan int64, stop func(), errc chan error) {
+		ctx, cancel := context.WithCancel(ctx)
+		valc = make(chan int64, 1)
+		errc = make(chan error, 1)
+		go func() { defer close(valc); errc <- client.Subscribe(ctx, valc, 100*time.Millisecond) }()
+		time.Sleep(100 * time.Millisecond)
+		return valc, cancel, errc
+	}
+
+	publish := func(v int64) {
+		t.Helper()
+		stats, err := client.Publish(ctx, v)
+		if err != nil {
+			t.Fatalf("publish: %v", err)
+		}
+		t.Logf("publish(%v): %v", v, stats)
+	}
+
+	recvAndCheck := func(valc <-chan int64, want int64) {
+		t.Helper()
+		select {
+		case v := <-valc:
+			if want != v {
+				t.Errorf("want %v, have %v", want, v)
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Fatalf("timeout waiting for value")
+		}
+	}
+
+	stopAndCheck := func(stopfunc func(), errc <-chan error) {
+		t.Helper()
+		stopfunc()
+		if err := <-errc; errors.Is(err, context.Canceled) {
+			err = nil
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	v1, s1, e1 := spawn()
+
+	publish(1)
+	recvAndCheck(v1, 1)
+
+	v2, s2, e2 := spawn()
+
+	publish(2)
+	recvAndCheck(v1, 2)
+	recvAndCheck(v2, 2)
+
+	stopAndCheck(s1, e1)
+
+	publish(3)
+	recvAndCheck(v1, 0)
+	recvAndCheck(v2, 3)
+
+	stopAndCheck(s2, e2)
+
+	publish(4)
+	recvAndCheck(v1, 0)
+	recvAndCheck(v2, 0)
+}

--- a/pshttp/util.go
+++ b/pshttp/util.go
@@ -1,0 +1,49 @@
+package pshttp
+
+import (
+	"encoding/json"
+	"fmt"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+func respondJSON(w http.ResponseWriter, code int, response any) error {
+	body, err := json.MarshalIndent(response, "", "    ")
+	if err != nil {
+		body = []byte(fmt.Sprintf(`{"error": "%s"}`, err.Error()))
+	}
+	w.Header().Set("content-type", "application/json; charset=utf-8")
+	w.WriteHeader(code)
+	_, err = w.Write(body)
+	return err
+}
+
+func requestExplicitlyAccepts(r *http.Request, acceptable ...string) bool {
+	accept := parseAcceptMediaTypes(r)
+	for _, want := range acceptable {
+		if _, ok := accept[want]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func parseAcceptMediaTypes(r *http.Request) map[string]map[string]string {
+	mediaTypes := map[string]map[string]string{} // type: params
+	for _, a := range strings.Split(r.Header.Get("accept"), ",") {
+		mediaType, params, err := mime.ParseMediaType(a)
+		if err != nil {
+			continue
+		}
+		mediaTypes[mediaType] = params
+	}
+	return mediaTypes
+}
+
+func parseDefault[T any](s string, parse func(string) (T, error), def T) T {
+	if v, err := parse(s); err == nil {
+		return v
+	}
+	return def
+}

--- a/pshttp/util.go
+++ b/pshttp/util.go
@@ -6,6 +6,7 @@ import (
 	"mime"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func respondJSON(w http.ResponseWriter, code int, response any) error {
@@ -46,4 +47,17 @@ func parseDefault[T any](s string, parse func(string) (T, error), def T) T {
 		return v
 	}
 	return def
+}
+
+func parseDurationMinMax(min, max time.Duration) func(string) (time.Duration, error) {
+	return func(s string) (time.Duration, error) {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return 0, err
+		}
+		if d < min || d > max {
+			return 0, fmt.Errorf("duration outside of min/max bounds")
+		}
+		return d, nil
+	}
 }


### PR DESCRIPTION
This PR adds package pshttp, which provides an HTTP interface to a ps.Broker. It includes two main components. 
pshttp.Handler wraps a ps.Broker and implements http.Handler. The handler accepts POST requests for publishing events, and GET requests for subscribing to events. Subscriptions are implemented via SSE, so GET requests must accept: text/event-stream. pshttp.Client wraps a remote URI, which is assumed to be handled by a pshttp.Handler. The client provides publish and subscribe methods.